### PR TITLE
Fixed the Bug of an Incorrect Password/Email Not giving the Correct Response

### DIFF
--- a/src/controller/account.js
+++ b/src/controller/account.js
@@ -41,7 +41,7 @@ export default ({ config, db }) => {
 				next();
 			}
     });
-	}, passport.authenticate('local', { session: false, scope: [] }), (err, req, res, next) => {
+	}, passport.authenticate('local', { session: false, scope: [], failWithError: true }), (err, req, res, next) => {
 		if (err) {
 			res.status(300).json({ message: `Password is incorrect`});
 		}

--- a/src/controller/account.js
+++ b/src/controller/account.js
@@ -43,7 +43,7 @@ export default ({ config, db }) => {
     });
 	}, passport.authenticate('local', { session: false, scope: [], failWithError: true }), (err, req, res, next) => {
 		if (err) {
-			res.status(300).json({ message: `Email or password invalid, please check your credentials`});
+			res.status(401).json({ message: `Email or password invalid, please check your credentials`});
 		}
 	}, generateAccessToken, respond);
 

--- a/src/controller/account.js
+++ b/src/controller/account.js
@@ -43,7 +43,7 @@ export default ({ config, db }) => {
     });
 	}, passport.authenticate('local', { session: false, scope: [], failWithError: true }), (err, req, res, next) => {
 		if (err) {
-			res.status(300).json({ message: `Password is incorrect`});
+			res.status(300).json({ message: `Email or password invalid, please check your credentials`});
 		}
 	}, generateAccessToken, respond);
 


### PR DESCRIPTION
When a user was trying to login via the `/v1/account/login` endpoint, they were not being given a correct response if they entered an incorrect username or password (they were just being given a generic unauthorized 401 message).

The reason for this was just because the `failWithError` option was missing so the catch for the error was never being hit.

I also tweaked the response code and message to make it cover both an incorrect password or email address.